### PR TITLE
Merge with master and fixed broken cli implemention

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -8,6 +8,8 @@ output = shippable/codecoverage/coverage.xml
 [report]
 # Regexes for lines to exclude from consideration
 exclude_lines =
+    pragma: no cover
+
     # Don't complain about missing debug-only code:
     def __repr__
     if self\.debug

--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,15 @@ docs/_build/
 
 # PyBuilder
 target/
+
+# pyenv
+.python-version
+
+# dotenv
+.env
+
+# Extras
+tabulator
+jsontableschema
+jsontableschema_bigquery
+jsontableschema_sql

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,14 @@
 language: python
+os:
+  - linux
 python:
+  - 2.7
+  - 3.3
+  - 3.4
   - 3.5
 sudo: false
 env:
-  fast_finish: true
-  matrix:
-    - TOXENV=py27
-    - TOXENV=py33
-    - TOXENV=py34
-    - TOXENV=py35
+  - TOXENV="py${PYTHON_VERSION//./}"
 install:
   - pip install tox coveralls
 script: tox

--- a/README.md
+++ b/README.md
@@ -1,12 +1,20 @@
 # DataPackage.py
 
-[![Build Status](https://travis-ci.org/datapackages/datapackage-py.svg)](https://travis-ci.org/datapackages/datapackage-py)
-[![Test Coverage](https://coveralls.io/repos/datapackages/datapackage-py/badge.svg?branch=master&service=github)](https://coveralls.io/github/datapackages/datapackage-py)
+[![Gitter](https://img.shields.io/gitter/room/frictionlessdata/chat.svg)](https://gitter.im/frictionlessdata/chat)
+[![Build Status](https://travis-ci.org/frictionlessdata/datapackage-py.svg?branch=master)](https://travis-ci.org/frictionlessdata/datapackage-py)
+[![Windows Build Status](https://ci.appveyor.com/api/projects/status/github/frictionlessdata/datapackage-py?branch=master&svg=true)](https://ci.appveyor.com/project/vitorbaptista/datapackage-py)
+[![Test Coverage](https://coveralls.io/repos/frictionlessdata/datapackage-py/badge.svg?branch=master&service=github)](https://coveralls.io/github/frictionlessdata/datapackage-py)
 ![Support Python versions 2.7, 3.3, 3.4 and 3.5](https://img.shields.io/badge/python-2.7%2C%203.3%2C%203.4%2C%203.5-blue.svg)
 
 A model for working with [Data Packages].
 
   [Data Packages]: http://dataprotocols.org/data-packages/
+  
+## Install
+
+```
+pip install datapackage
+```
 
 ## Examples
 
@@ -90,6 +98,58 @@ with open('datapackage.json', 'w') as f:
   f.write(dp.to_json())
 # {"name": "my_sleep_duration", "resources": [{"data": [7, 8, 5, 6, 9, 7, 8], "name": "data"}]}
 ```
+
+### Using a schema that's not in the local cache
+
+```python
+import datapackage
+import datapackage.registry
+
+# This constant points to the official registry URL
+# You can use any URL or path that points to a registry CSV
+registry_url = datapackage.registry.Registry.DEFAULT_REGISTRY_URL
+registry = datapackage.registry.Registry(registry_url)
+
+metadata = {}  # The datapackage.json file
+schema = registry.get('tabular')  # Change to your schema ID
+
+dp = datapackage.DataPackage(metadata, schema)
+```
+
+### Push/pull Data Package to storage
+
+Package provides `push_datapackage` and `pull_datapackage` utilities to
+push and pull to/from storage.
+
+This functionality requires `jsontableschema` storage plugin installed. See
+[plugins](#https://github.com/frictionlessdata/jsontableschema-py#plugins)
+section of `jsontableschema` docs for more information. Let's imagine
+we have installed `jsontableschema-mystorage` (not a real name) plugin.
+
+Then we could push and pull datapackage to/from the storage:
+
+> All parameters should be used as keyword arguments.
+
+```python
+from datapackage import push_datapackage, pull_datapackage
+
+# Push
+push_datapackage(
+    descriptor='descriptor_path',
+    backend='mystorage', **<mystorage_options>)
+
+# Import
+pull_datapackage(
+    descriptor='descriptor_path', name='datapackage_name',
+    backend='mystorage', **<mystorage_options>)
+```
+
+Options could be a SQLAlchemy engine or a BigQuery project and dataset name etc.
+Detailed description you could find in a concrete plugin documentation.
+
+See concrete examples in
+[plugins](#https://github.com/frictionlessdata/jsontableschema-py#plugins)
+section of `jsontableschema` docs.
 
 ## Developer notes
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,18 @@
+environment:
+  matrix:
+    - PYTHON: 'C:\\Python27'
+      TOXENV: 'py27'
+    - PYTHON: 'C:\\Python33'
+      TOXENV: 'py33'
+    - PYTHON: 'C:\\Python34'
+      TOXENV: 'py34'
+    - PYTHON: 'C:\\Python35'
+      TOXENV: 'py35'
+
+install:
+  - '%PYTHON%\\python.exe -m pip install tox'
+
+build: off
+
+test_script:
+  - '%PYTHON%\\scripts\\tox'

--- a/datapackage/__init__.py
+++ b/datapackage/__init__.py
@@ -1,2 +1,3 @@
 from .datapackage import DataPackage
+from .pushpull import push_datapackage, pull_datapackage
 from .resource import Resource

--- a/datapackage/helpers.py
+++ b/datapackage/helpers.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import os
+
+
+# Module API
+
+def ensure_dir(path):
+    """Ensure directory exists.
+
+    Args:
+        path (str): file path inside the directory to ensure
+
+    """
+    dirpath = os.path.dirname(path)
+    if dirpath and not os.path.exists(dirpath):
+        os.makedirs(dirpath)

--- a/datapackage/mappers.py
+++ b/datapackage/mappers.py
@@ -1,0 +1,107 @@
+# -*- coding: utf-8 -*-
+from __future__ import division
+from __future__ import print_function
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
+import os
+import re
+from copy import deepcopy
+
+
+# Module API
+
+def convert_path(path, name):
+    """Convert resource's path and name to storage's table name.
+
+    Args:
+        path (str): resource path
+        name (str): resource name
+
+    Returns:
+        str: table name
+
+    """
+    table = os.path.splitext(path)[0]
+    table = table.replace(os.path.sep, '__')
+    if name is not None:
+        table = '___'.join([table, name])
+    table = re.sub('[^0-9a-zA-Z_]+', '_', table)
+    table = table.lower()
+    return table
+
+
+def restore_path(table):
+    """Restore resource's path and name from storage's table.
+
+    Args:
+        table (str): table name
+
+    Returns:
+        (str, str): resource path and name
+
+    """
+    name = None
+    splited = table.split('___')
+    path = splited[0]
+    if len(splited) == 2:
+        name = splited[1]
+    path = path.replace('__', os.path.sep)
+    path += '.csv'
+    return path, name
+
+
+def convert_schemas(mapping, schemas):
+    """Convert schemas to be compatible with storage schemas.
+
+    Foreign keys related operations.
+
+    Args:
+        mapping (dict): mapping between resource name and table name
+        schemas (list): schemas
+
+    Raises:
+        ValueError: if there is no resource
+            for some foreign key in given mapping
+
+    Returns:
+        list: converted schemas
+
+    """
+    schemas = deepcopy(schemas)
+    for schema in schemas:
+        for fk in schema.get('foreignKeys', []):
+            resource = fk['reference']['resource']
+            if resource != 'self':
+                if resource not in mapping:
+                    message = 'Not resource "%s" for foreign key "%s"'
+                    message = message % (resource, fk)
+                    raise ValueError(message)
+                fk['reference']['resource'] = '<table>'
+                fk['reference']['table'] = mapping[resource]
+    return schemas
+
+
+def restore_resources(resources):
+    """Restore schemas from being compatible with storage schemas.
+
+    Foreign keys related operations.
+
+    Args:
+        list: resources from storage
+
+    Returns:
+        list: restored resources
+
+    """
+    resources = deepcopy(resources)
+    for resource in resources:
+        schema = resource['schema']
+        for fk in schema.get('foreignKeys', []):
+            fkresource = fk['reference']['resource']
+            if fkresource == '<table>':
+                table = fk['reference']['table']
+                _, name = restore_path(table)
+                del fk['reference']['table']
+                fk['reference']['resource'] = name
+    return resources

--- a/datapackage/pushpull.py
+++ b/datapackage/pushpull.py
@@ -1,0 +1,141 @@
+# -*- coding: utf-8 -*-
+from __future__ import division
+from __future__ import print_function
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
+import io
+import os
+import six
+import json
+import unicodecsv as csv
+from copy import deepcopy
+from importlib import import_module
+from jsontableschema.model import SchemaModel
+
+from . import helpers
+from . import mappers
+from .datapackage import DataPackage
+
+
+# Module API
+
+def push_datapackage(descriptor, backend, **backend_options):
+    """Push Data Package to storage.
+
+    All parameters should be used as keyword arguments.
+
+    Args:
+        descriptor (str): path to descriptor
+        backend (str): backend name like `sql` or `bigquery`
+        backend_options (dict): backend options mentioned in backend docs
+
+    """
+
+    # Init maps
+    tables = []
+    schemas = []
+    datamap = {}
+    mapping = {}
+
+    # Init model
+    model = DataPackage(descriptor)
+
+    # Get storage
+    plugin = import_module('jsontableschema.plugins.%s' % backend)
+    storage = plugin.Storage(**backend_options)
+
+    # Collect tables/schemas/data
+    for resource in model.resources:
+        name = resource.metadata.get('name', None)
+        table = mappers.convert_path(resource.metadata['path'], name)
+        schema = resource.metadata['schema']
+        data = resource.iter()
+        # TODO: review
+        def values(schema, data):
+            for item in data:
+                row = []
+                for field in schema['fields']:
+                    row.append(item.get(field['name'], None))
+                yield tuple(row)
+        tables.append(table)
+        schemas.append(schema)
+        datamap[table] = values(schema, data)
+        if name is not None:
+            mapping[name] = table
+    schemas = mappers.convert_schemas(mapping, schemas)
+
+    # Create tables
+    for table in tables:
+        if storage.check(table):
+            storage.delete(table)
+    storage.create(tables, schemas)
+
+    # Write data to tables
+    for table in storage.tables:
+        if table in datamap:
+            storage.write(table, datamap[table])
+
+
+def pull_datapackage(descriptor, name, backend, **backend_options):
+    """Pull Data Package from storage.
+
+    All parameters should be used as keyword arguments.
+
+    Args:
+        descriptor (str): path where to store descriptor
+        name (str): name of the pulled datapackage
+        backend (str): backend name like `sql` or `bigquery`
+        backend_options (dict): backend options mentioned in backend docs
+
+    """
+
+    # Save datapackage name
+    datapackage_name = name
+
+    # Get storage
+    plugin = import_module('jsontableschema.plugins.%s' % backend)
+    storage = plugin.Storage(**backend_options)
+
+    # Iterate over tables
+    resources = []
+    for table in storage.tables:
+
+        # Prepare
+        schema = storage.describe(table)
+        base = os.path.dirname(descriptor)
+        path, name = mappers.restore_path(table)
+        fullpath = os.path.join(base, path)
+
+        # Write data
+        helpers.ensure_dir(fullpath)
+        with io.open(fullpath, 'wb') as file:
+            model = SchemaModel(deepcopy(schema))
+            data = storage.read(table)
+            writer = csv.writer(file, encoding='utf-8')
+            writer.writerow(model.headers)
+            for row in data:
+                writer.writerow(row)
+
+        # Add resource
+        resource = {'schema': schema, 'path': path}
+        if name is not None:
+            resource['name'] = name
+        resources.append(resource)
+
+    # Write descriptor
+    mode = 'w'
+    encoding = 'utf-8'
+    if six.PY2:
+        mode = 'wb'
+        encoding = None
+    resources = mappers.restore_resources(resources)
+    helpers.ensure_dir(descriptor)
+    with io.open(descriptor,
+                 mode=mode,
+                 encoding=encoding) as file:
+        descriptor = {
+            'name': datapackage_name,
+            'resources': resources,
+        }
+        json.dump(descriptor, file, indent=4)

--- a/datapackage/registry.py
+++ b/datapackage/registry.py
@@ -23,6 +23,7 @@ class Registry(object):
         RegistryError: If there was some problem opening the registry file or
             its format was incorrect.
     '''
+    DEFAULT_REGISTRY_URL = 'http://schemas.datapackages.org/registry.csv'
     DEFAULT_REGISTRY_PATH = os.path.join(
         os.path.dirname(os.path.abspath(__file__)),
         'schemas',

--- a/datapackage/resource.py
+++ b/datapackage/resource.py
@@ -268,8 +268,19 @@ class TabularResource(Resource):
             inline_data = self._parse_inline_data()
             result = iter(inline_data)
         elif data_path_or_url:
+            dialect = self.metadata.get('dialect', {})
+            parser_options = {}
+            parser_class = None
+            if 'delimiter' in dialect:
+                parser_options['delimiter'] = dialect['delimiter']
+            if 'lineTerminator' in dialect:
+                parser_options['lineterminator'] = dialect['lineTerminator']
+            if len(dialect) > 0:
+                parser_class = tabulator.parsers.CSV
             try:
-                table = tabulator.topen(data_path_or_url, with_headers=True)
+                table = tabulator.topen(data_path_or_url, with_headers=True,
+                                        parser_class=parser_class,
+                                        parser_options=parser_options)
                 result = TabulatorIterator(table)
             except tabulator.errors.Error as e:
                 msg = 'Data at \'{0}\' isn\'t in a known tabular data format'

--- a/datapackage/schemas/fiscal-data-package.json
+++ b/datapackage/schemas/fiscal-data-package.json
@@ -3,7 +3,7 @@
   "title": "Fiscal Data Package",
   "description": "Fiscal Data Package is a simple specification for data access and delivery of fiscal data.",
   "type": "object",
-  "required": [ "name", "title", "resources", "mapping" ],
+  "required": [ "name", "title", "resources", "model" ],
   "properties": {
     "name": {
       "$ref": "definitions.json#/define/name",
@@ -170,9 +170,9 @@
       },
       "required": ["start"]
     },
-    "mapping": {
-      "title": "Mapping",
-      "description": "The mapping hash provides a way to link the 'physical' model - the data in CSV files - to a more general, conceptual, 'logical' model for fiscal information.",
+    "model": {
+      "title": "Model",
+      "description": "The 'logical model' for the data",
       "type": "object",
       "properties": {
         "measures": {

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,5 @@
 [bdist_wheel]
 universal = 1
+
+[metadata]
+description-file = README.md

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ def schema_files():
 
 setup(
     name='datapackage',
-    version='0.0.1',
+    version='0.6.0',
     description=(
         'Utilities to work with Data Packages as defined on dataprotocols.org'
     ),
@@ -48,7 +48,7 @@ setup(
     license='MIT',
 
     classifiers=[
-        'Development Status :: 3 - Alpha',
+        'Development Status :: 4 - Beta',
 
         'Intended Audience :: Developers',
         'Intended Audience :: Information Technology',
@@ -59,9 +59,10 @@ setup(
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
     ],
 
-    keywords='data dataprotocols jsontableschema openrefine datascience',
+    keywords='data dataprotocols jsontableschema frictionlessdata datascience',
 
     packages=find_packages(exclude=['tests']),
     package_data={'datapackage': schema_files()},
@@ -70,7 +71,9 @@ setup(
         'six >= 1.10.0',
         'requests >= 2.8.0',
         'jsonschema >= 2.5.1',
-        'tabulator >= 0.3.3',
+        'tabulator >= 0.3.6',
+        'jsontableschema >= 0.5.1',
+        'unicodecsv>=0.14',
         'click',
     ],
     entry_points={

--- a/setup.py
+++ b/setup.py
@@ -74,11 +74,10 @@ setup(
         'tabulator >= 0.3.6',
         'jsontableschema >= 0.5.1',
         'unicodecsv>=0.14',
-        'click',
     ],
     entry_points={
         "console_scripts": [
-           "datapackage=datapackage.cli_datapackage_validate:main",
+            "datapackage=datapackage.cli:main",
         ],
     }
 )

--- a/tests/fixtures/datapackage/data.csv
+++ b/tests/fixtures/datapackage/data.csv
@@ -1,0 +1,3 @@
+id,city
+1,London
+2,Paris

--- a/tests/fixtures/datapackage/datapackage.json
+++ b/tests/fixtures/datapackage/datapackage.json
@@ -1,0 +1,21 @@
+{
+    "name": "datapackage",
+    "resources": [
+        {
+            "name": "data",
+            "path": "data.csv",
+            "schema": {
+                "fields": [
+                    {
+                        "name": "id",
+                        "type": "integer"
+                    },
+                    {
+                        "name": "city",
+                        "type": "string"
+                    }
+                ]
+            }
+        }
+    ]
+}

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,63 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import six
+try:
+    import mock
+except ImportError:
+    import unittest.mock as mock
+
+from tests import test_helpers
+from datapackage import cli
+
+
+class CommandCaller(object):
+
+    def __init__(self, args):
+        stdout = six.BytesIO()
+        stderr = six.BytesIO()
+        with mock.patch('sys.exit') as exit_mock:
+            cli.main(args, stdout, stderr)
+            if exit_mock.call_args:
+                self.exit_code = exit_mock.call_args[0][0]
+            else:
+                self.exit_code = None
+        self.stdout = stdout.getvalue().decode('utf-8')
+        self.stderr = stderr.getvalue().decode('utf-8')
+
+
+def test_validate():
+    path = test_helpers.fixture_path('datapackage/datapackage.json')
+    result = CommandCaller(['validate', path])
+    assert result.exit_code == 0
+    assert result.stdout == 'valid\n'
+
+
+def test_validate_dir():
+    path = test_helpers.fixture_path('datapackage')
+    result = CommandCaller(['validate', path])
+    assert result.exit_code == 0
+    assert result.stdout == 'valid\n'
+
+
+def test_validate_schema_error():
+    path = test_helpers.fixture_path('empty_datapackage.json')
+    result = CommandCaller(['validate', path])
+    assert result.exit_code == 1
+    if six.PY2:
+        assert result.stderr.startswith("Error: u'name' is a required property\n")
+    else:
+        assert result.stderr.startswith("Error: 'name' is a required property\n")
+
+
+def test_validate_file_error():
+    path = test_helpers.fixture_path('missing_datapackage.json')
+    result = CommandCaller(['validate', path])
+    assert result.exit_code == 1
+    assert result.stderr == (
+        "Error: '%s' is neither an existing directory neither an existing "
+        "file.\n"
+    ) % path

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,4 +1,8 @@
 import os
+import shutil
+import tempfile
+from importlib import import_module
+module = import_module('datapackage.helpers')
 
 
 __FIXTURES_PATH = os.path.join(
@@ -6,6 +10,17 @@ __FIXTURES_PATH = os.path.join(
     'fixtures'
 )
 
+def fixture_path(fixture, *paths):
+    return os.path.join(__FIXTURES_PATH, fixture, *paths)
 
-def fixture_path(fixture):
-    return os.path.join(__FIXTURES_PATH, fixture)
+
+def test_ensure_dir():
+    base_path = tempfile.mkdtemp()
+    try:
+        dir_path = os.path.join(base_path, 'dir')
+        file_path = os.path.join(dir_path, 'file')
+        assert not os.path.isdir(dir_path)
+        module.ensure_dir(file_path)
+        assert os.path.isdir(dir_path)
+    finally:
+        shutil.rmtree(base_path)

--- a/tests/test_mappers.py
+++ b/tests/test_mappers.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+from __future__ import division
+from __future__ import print_function
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
+import pytest
+from importlib import import_module
+module = import_module('datapackage.mappers')
+
+
+# Tests
+
+def test_convert_path():
+    assert module.convert_path('path.csv', 'name') == 'path___name'
+    assert module.convert_path('dir/path.csv', 'name') == 'dir__path___name'
+    assert module.convert_path('path.csv', 'Some Name') == 'path___some_name'
+
+
+def test_restore_path():
+    assert module.restore_path('path___name') == ('path.csv', 'name')
+    assert module.restore_path('dir__path___name') == ('dir/path.csv', 'name')
+    assert module.restore_path('path___some_name') == ('path.csv', 'some_name')
+
+
+def test_convert_schemas_self_reference():
+    mapping = {}
+    schema = {'foreignKeys': [{'reference': {'resource': 'self'}}]}
+    result = module.convert_schemas(mapping, [schema])
+    assert result[0] == schema
+
+
+def test_convert_schemas_resource_reference():
+    mapping = {'resource_name': 'table_name'}
+    schema = {'foreignKeys': [{'reference': {'resource': 'resource_name'}}]}
+    result = module.convert_schemas(mapping, [schema])
+    assert result[0] == {'foreignKeys':
+        [{'reference': {'resource': '<table>', 'table': 'table_name'}}]}
+
+
+def test_convert_schemas_resource_missing():
+    mapping = {}
+    schema = {'foreignKeys': [{'reference': {'resource': 'resource_name'}}]}
+    with pytest.raises(ValueError):
+        module.convert_schemas(mapping, [schema])
+
+
+def test_restore_resources():
+    resource = {'schema': {'foreignKeys':
+        [{'reference': {'resource': '<table>', 'table': 'path___name'}}]}}
+    result = module.restore_resources([resource])
+    assert result[0] == {'schema': {'foreignKeys':
+        [{'reference': {'resource': 'name'}}]}}

--- a/tests/test_pushpull.py
+++ b/tests/test_pushpull.py
@@ -1,0 +1,84 @@
+# -*- coding: utf-8 -*-
+from __future__ import division
+from __future__ import print_function
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
+import os
+import mock
+import pytest
+import shutil
+import tempfile
+import tests.test_helpers as helpers
+from mock import patch, ANY
+from datapackage import DataPackage
+from importlib import import_module
+module = import_module('datapackage.pushpull')
+
+
+# Tests
+
+def test_push_datapackage(storage):
+
+    # Prepare and call
+    descriptor = helpers.fixture_path('datapackage', 'datapackage.json')
+    storage.tables = ['data___data']  # Without patch it's a reflection
+    module.push_datapackage(descriptor=descriptor, backend='backend')
+
+    # Assert mocked calls
+    storage.create.assert_called_with(
+        ['data___data'],
+        [{'fields': [
+            {'name': 'id', 'type': 'integer'},
+            {'name': 'city', 'type': 'string'}]}])
+    storage.write.assert_called_with('data___data', ANY)
+
+    # Assert writen data
+    data = storage.write.call_args[0][1]
+    assert list(data) == [
+        ('1', 'London'),
+        ('2', 'Paris'),
+    ]
+
+
+def test_pull_datapackage(storage, descriptor):
+
+    # Prepare and call
+    storage.tables = ['data___data']
+    storage.describe.return_value = (
+        {'fields': [
+            {'name': 'id', 'type': 'integer'},
+            {'name': 'city', 'type': 'string'}]})
+    storage.read.return_value = [
+        (1, 'London'),
+        (2, 'Paris'),
+    ]
+    module.pull_datapackage(descriptor=descriptor, name='name', backend='backend')
+
+    # Assert pulled datapackage
+    dp = DataPackage(descriptor)
+    assert dp.metadata == {'name': 'name', 'resources': [
+        {'path': 'data.csv', 'name': 'data', 'schema':
+            {'fields': [
+                {'name': 'id', 'type': 'integer'},
+                {'name': 'city', 'type': 'string'}]}}]}
+
+
+# Fixtures
+
+@pytest.fixture
+def storage(request):
+    import_module = patch.object(module, 'import_module').start()
+    storage = import_module.return_value.Storage.return_value
+    request.addfinalizer(patch.stopall)
+    return storage
+
+
+@pytest.fixture
+def descriptor(request):
+    basedir = tempfile.mkdtemp()
+    descriptor = os.path.join(basedir, 'datapackage.json')
+    def delete():
+        shutil.rmtree(basedir)
+    request.addfinalizer(delete)
+    return descriptor

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -83,6 +83,10 @@ class TestRegistry(object):
         with pytest.raises(RegistryError):
             datapackage.registry.Registry(registry_path)
 
+    def test_it_has_default_registry_url_const(self):
+        url = 'http://schemas.datapackages.org/registry.csv'
+        assert datapackage.registry.Registry.DEFAULT_REGISTRY_URL == url
+
     def test_available_profiles_returns_empty_dict_when_registry_is_empty(self):
         registry_path = self.EMPTY_REGISTRY_PATH
         registry = datapackage.registry.Registry(registry_path)

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,7 @@ envlist=
   py33
   py34
   py35
+skip_missing_interpreters = true
 
 [testenv]
 passenv = TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH


### PR DESCRIPTION
Things fixed:

- Updated old datapackage_validate api to new one, that was merged into datapackage.
- Replaced click with argparse. Click complains about unicode_literals imports and does not work well with Python 3 (see: http://click.pocoo.org/5/python3/).
- Wrote tests for new datapackage.cli module.

Run tests on py27, py34, py35, all tests pass.

Accept this pull request to update existing https://github.com/frictionlessdata/datapackage-py/pull/50 pull request.